### PR TITLE
Fix textile link issue in Asia Languages.

### DIFF
--- a/src/Netcarver/Textile/Parser.php
+++ b/src/Netcarver/Textile/Parser.php
@@ -4216,7 +4216,7 @@ class Parser
 
     protected function replaceLinks($text)
     {
-        $stopchars = "\s|^'\"*";
+        $stopchars = "\s|^'\"*[";
 
         return (string)preg_replace_callback(
             '/


### PR DESCRIPTION
The function "replaceLinks" doesn't works if one link follows another without a white space between them, this always happens in Asia Languages, like Chinese.

So, added a char '[' to fix this.

<!--- Provide a general summary of your changes in the title above. -->

<!--- Please replace `{Please write here}` with your answers as best you can. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Type of change
<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Security fix

### Description
<!--- Describe your changes in detail. -->
`<?php
require '../../vendor/autoload.php';
$parser = new \Netcarver\Textile\Parser();

echo $parser->parse('
Line1. ["a1":link1] ["a2":link2]
Line2. ["a1":link1]["a2":link2]

[link1]https://alternativeto.cn
[link2]https://alternativeto.cn
');`

The function 'replaceLinks' works fine at Line1, but is breaks at line 2, because the regex matches in greedy mode. The next stop char '[' can fix this.

### Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I documented my additions and changes using PHPdoc.
- [x] I wrote fixtures to cover my additions.
- [ ] `$ composer update`
- [ ] `$ composer test`
- [ ] `$ composer cs`
